### PR TITLE
Adding an analytics component

### DIFF
--- a/packages/core/src/components/Analytics.tsx
+++ b/packages/core/src/components/Analytics.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface Props {
+  property?: 'website' | 'app';
+}
+
+export function Analytics(props: Props) {
+  let scriptMarkup = null;
+
+  switch (props.property) {
+    case 'website':
+      scriptMarkup = (
+        <>
+          <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-4YLH34D18N"
+          />
+          <script
+            async
+            dangerouslySetInnerHTML={{
+              __html: `
+            Bloop`,
+            }}
+          />
+        </>
+      );
+      break;
+    case 'app':
+      scriptMarkup = (
+        <script
+          async
+          dangerouslySetInnerHTML={{
+            __html: `
+Google Analytics for the Fondfolio app`,
+          }}
+        />
+      );
+      break;
+    default:
+      break;
+  }
+  return <>{scriptMarkup}</>;
+}

--- a/packages/core/src/components/index.tsx
+++ b/packages/core/src/components/index.tsx
@@ -10,6 +10,7 @@ export {Card} from './Card';
 export {Header} from './Header';
 export {Footer} from './Footer';
 export {Support} from './Support';
+export {Analytics} from './Analytics';
 export {Mast} from './Mast';
 export {Flag} from './Flag';
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "outDir": "build",
     "tsBuildInfoFile": "build/.tsbuildinfo",

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -40,6 +40,7 @@ import {
   Checkbox,
   Footer,
   Support,
+  Analytics,
   ChoiceList,
   usePageTitle,
   Caps,


### PR DESCRIPTION
@cartogram I seem to be hitting a wall when trying to use this in the Website. I copied the method we’re using to import the MessageBird script in the Support component, but when I try to use it in the _app.tsx in the website project I get an error.

Here’s my code in pages/_app.tsx:
`      import React from 'react';
import {AppProps} from 'next/app';
import {Provider as MinouProvider, DOMAINS, Display, Analytics} from 'minou';
import {Graphql} from 'components';

export default function FondfolioWebsite({Component, pageProps}: AppProps) {
  return (
    <MinouProvider domain={DOMAINS.website}>
      <Graphql>
        <Analytics property="website" />
        <Component {...pageProps} />
      </Graphql>
    </MinouProvider>
  );
}
`
This is the error I get when I tophat it in the website project:
`Unhandled Runtime Error
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `FondfolioWebsite`.`

Any advice?